### PR TITLE
zfs-impermanence: make postCreateHook idempotent

### DIFF
--- a/zfs-impermanence/disko-config.nix
+++ b/zfs-impermanence/disko-config.nix
@@ -70,7 +70,7 @@
             type = "zfs_fs";
             mountpoint = "/";
             options."com.sun:auto-snapshot" = "false";
-            postCreateHook = "zfs snapshot zroot/local/root@blank";
+            postCreateHook = "zfs list -t snapshot -H -o name | grep -E '^zroot/local/root@blank$' || zfs snapshot zroot/local/root@blank";
           };
         };
       };


### PR DESCRIPTION
Without this, one of the disko nixos tests fails with:

    vm-test-run-disko-nixos-disko> machine # + zfs snapshot zroot/local/root@blank
    vm-test-run-disko-nixos-disko> machine # cannot create snapshot 'zroot/local/root@blank': dataset already exists

See https://github.com/nix-community/disko/commit/f6b72bfed7c57997aa5dccd94a3ebbc4cb824b04