### PR TITLE
link to disko repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # disko-templates
 
-Disko templates to copy into your project
+[Disko](https://github.com/nix-community/disko) templates to copy into your project
 
 Usage:
 


### PR DESCRIPTION
I thought it would be convenient to link back to the Disko repository in the README.